### PR TITLE
Allow empty colPos in PHP 8.1

### DIFF
--- a/Classes/BackendLayout/BackendLayoutConfiguration.php
+++ b/Classes/BackendLayout/BackendLayoutConfiguration.php
@@ -80,7 +80,7 @@ class BackendLayoutConfiguration
                 }
 
                 foreach ($row['columns.'] as $column) {
-                    if ($column['colPos'] !== '' && $colPos === (int)$column['colPos']) {
+                    if (isset($column['colPos']) && $column['colPos'] !== '' && $colPos === (int)$column['colPos']) {
                         $configuration = $column;
                         break 2;
                     }


### PR DESCRIPTION
The TYPO3 backend allows to have columns with empty colPos. It can be used to give the editor an impression of how his contents will be aligned in the frontend.

This example code snippet without a colPos is completely valid ...

```yaml
2 {
  columns {
    1 {
      name = LLL:EXT:my_ext/Resources/Private/Language/locallang_db.xlf:layout.template.row.2.contenttable.40.white
      colspan = 2
    }
    2 {
      name = LLL:EXT:my_ext/Resources/Private/Language/locallang_db.xlf:layout.template.row.2.content.60.white
      colspan = 4
      colPos = 1
      allowed {
        CType = header, text, textmedia
      }
    }
  }
}
```

... and results in a view like this:

<img width="1059" alt="Bildschirmfoto 2022-08-10 um 09 14 59" src="https://user-images.githubusercontent.com/16088567/183839149-42636ded-eddc-4c43-8107-4603eec04b5b.png">

This patch introduces an additional check for compatibility with PHP 8.1 to not run into an exception for missing colPos definition.

![Bildschirmfoto 2022-08-10 um 09 20 05](https://user-images.githubusercontent.com/16088567/183839664-d680d284-bd39-4b84-ade3-5b404d4a6c80.png)

